### PR TITLE
Fix/load-view-rootviewcontroller

### DIFF
--- a/Frameworks/SpecUIKitFringes/SpecUIKitFringes/UIWindow+HolistiKit.swift
+++ b/Frameworks/SpecUIKitFringes/SpecUIKitFringes/UIWindow+HolistiKit.swift
@@ -18,13 +18,13 @@ extension UIWindow {
             if let previous = _rootViewController {
                 _rootViewController = newValue
                 previous.viewWillDisappear(false)
-                newValue?.viewDidLoad()
+                _ = newValue?.view
                 newValue?.viewWillAppear(false)
                 previous.viewDidDisappear(false)
                 newValue?.viewDidAppear(false)
             } else {
                 _rootViewController = newValue
-                newValue?.viewDidLoad()
+                _ = newValue?.view
                 newValue?.viewWillAppear(false)
                 newValue?.viewDidAppear(false)
             }


### PR DESCRIPTION
When assigning a root view controller to the window, a call to`viewDidLoad` was made, and in some cases before the view was actually loaded.